### PR TITLE
setUser has been deprecated, also should not show up as in error in development mode

### DIFF
--- a/angular-raven.js
+++ b/angular-raven.js
@@ -29,7 +29,7 @@ module.provider('Raven', function() {
       },
       setUserContext: function setUserContext(user) {
         if (_development) {
-          $log.error('Raven: User ', user);
+          $log.info('Raven: User ', user);
         } else {
           $window.Raven.setUserContext(user);
         }


### PR DESCRIPTION
setUser has been deprecated in favor of setUserContext
Also, setUser logs an error to the console whenever setting a user in development mode, which is rather annoying. I think logging it as info is a bit more appropriate, as it isn't an error.
