### PR TITLE
Always dump exceptions to the console

### DIFF
--- a/angular-raven.js
+++ b/angular-raven.js
@@ -14,9 +14,8 @@
         VERSION: ($window.Raven) ? $window.Raven.VERSION : 'development',
         TraceKit: ($window.Raven) ? $window.Raven.TraceKit : 'development',
         captureException: function captureException(exception, cause) {
-          if (_development) {
-            $log.error('Raven: Exception ', exception, cause);
-          } else {
+          $log.error('Raven: Exception ', exception, cause);
+          if (!_development) {
             $window.Raven.captureException(exception, cause);
           }
         },


### PR DESCRIPTION
My team pulled our hair over this one for a while before we realized this was swallowing errors. Opinionated pull request but seems like dumping exceptions to console is probably always a good idea.
